### PR TITLE
Komischen Fehler gefixt, wenn der Bot abstürzt

### DIFF
--- a/run.py
+++ b/run.py
@@ -54,5 +54,6 @@ while 1:
             if channelUserCount[i] == 0:
                 if pBot.channellist[i] not in ORIGINALCHANNELS:
                     pBot.delChannel(pBot.channellist[i])
-                    break
+            else:
+                break
     time.sleep(5)


### PR DESCRIPTION
Fehler verhindert, bei dem der Bot versucht eine Char-Corner zu erstellen, die es schon gibt und abstürzt.
